### PR TITLE
Django 5.0 compatibility: Replace GeoModelAdmin with GISModelAdmin

### DIFF
--- a/osmflex/admin.py
+++ b/osmflex/admin.py
@@ -6,7 +6,7 @@ from osmflex import models
 # Register your models here.
 
 
-class OsmFlexAdmin(admin.GeoModelAdmin):  # type: ignore
+class OsmFlexAdmin(admin.GISModelAdmin):  # type: ignore
     search_fields = ("name",)
     list_display = ("osm_id", "osm_type", "name")
     list_filter = ("osm_type",)
@@ -211,7 +211,7 @@ class TrafficPolygonAdmin(OsmFlexAdmin):
 
 
 @admin.register(models.Unitable)
-class UnitableAdmin(admin.GeoModelAdmin):  # type: ignore
+class UnitableAdmin(admin.GISModelAdmin):  # type: ignore
     ...
 
 


### PR DESCRIPTION
That's all is necessary to get all of Bilum's test to run.
I'm wondering if we should keep this compatible with Django versions that do not have GISModelAdmin (<4.0), I guess it depends if it's still used in older deployments that are still under active development.